### PR TITLE
Friendlier input validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ PWInput is missing required inputs:
       - ntyp (int): number of types of atoms in the unit cell
   atomic_positions: required — choose 'unit': ['alat', 'bohr', 'angstrom', 'crystal', 'crystal_sg']
   k_points [kind='automatic']:
-      - grid (tuple)
+      - grid (tuple[int, int, int]): Monkhorst-Pack mesh dimensions (nk1, nk2, nk3): number of
+        k-points along each reciprocal-lattice direction of the uniform grid.
   cell_parameters: missing discriminator 'unit' (one of ['alat', 'bohr', 'angstrom'])
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,40 @@ QE namelist branches with mutually-exclusive layouts (e.g. PP's `PLOT`
 namelist discriminated on `iflag`) are exposed as pydantic discriminated
 unions, so the right variant is picked automatically from the input data.
 
+### Readable error reports
+
+Construction raises a standard `pydantic.ValidationError`. Pass the caught
+error to `pydantic_espresso.errors.explain` for a grouped, recursive summary
+that names each missing input together with its type, units, and help text:
+
+```python
+from pydantic import ValidationError
+from pydantic_espresso.errors import explain
+from pydantic_espresso.models.pw.develop import PWInput
+
+try:
+    inp = PWInput(
+        system={"ibrav": 0, "ecutwfc": 30.0},                     # missing nat, ntyp
+        cell_parameters={"vectors": [[1, 0, 0], [0, 1, 0], [0, 0, 1]]},  # missing 'unit'
+        k_points={"kind": "automatic"},                           # missing grid
+        # atomic_positions omitted entirely
+    )
+except ValidationError as exc:
+    print(explain(exc, PWInput))
+```
+
+```text
+PWInput is missing required inputs:
+  system:
+      - nat (int): number of atoms in the unit cell (ALL atoms, except if space_group is set, in
+        which case, INEQUIVALENT atoms)
+      - ntyp (int): number of types of atoms in the unit cell
+  atomic_positions: required — choose 'unit': ['alat', 'bohr', 'angstrom', 'crystal', 'crystal_sg']
+  k_points [kind='automatic']:
+      - grid (tuple)
+  cell_parameters: missing discriminator 'unit' (one of ['alat', 'bohr', 'angstrom'])
+```
+
 ### Command Line Interface
 
 The `pydantic_espresso` command line tool ships with the package but requires

--- a/src/pydantic_espresso/base.py
+++ b/src/pydantic_espresso/base.py
@@ -5,7 +5,12 @@ from pydantic_espresso.utils import INDENT, BaseModel
 
 
 class EspressoInput(BaseModel):
-    """Template pydantic model for the input of a Quantum ESPRESSO executable."""
+    """Template pydantic model for the input of a Quantum ESPRESSO executable.
+
+    Construction raises the usual :class:`pydantic.ValidationError` when inputs
+    are missing or invalid; pass the caught error to
+    :func:`pydantic_espresso.errors.explain` for a readable, recursive summary.
+    """
 
     def __str__(self) -> str:
         out = ""

--- a/src/pydantic_espresso/errors.py
+++ b/src/pydantic_espresso/errors.py
@@ -91,14 +91,20 @@ def _discriminator_options(field: FieldInfo) -> list[Any]:
 
 
 def _annotation_str(annotation: Any) -> str:
-    """Render a field annotation compactly (basic type name, or a trimmed Literal)."""
-    if get_origin(annotation) is Literal:
+    """Render a field annotation compactly (basic type, container, or trimmed Literal)."""
+    if hasattr(annotation, "__metadata__"):  # Annotated[X, ...] -> X
+        annotation = annotation.__origin__
+    origin = get_origin(annotation)
+    if origin is Literal:
         values = get_args(annotation)
         shown = ", ".join(repr(v) for v in values[:6])
         if len(values) > 6:
             shown += f", … ({len(values)} options)"
         return f"Literal[{shown}]"
-    if isinstance(annotation, type):
+    if origin in (tuple, list, set, frozenset):
+        inner = ", ".join(_annotation_str(arg) for arg in get_args(annotation))
+        return f"{origin.__name__}[{inner}]" if inner else origin.__name__
+    if origin is None and isinstance(annotation, type):
         return annotation.__name__
     return str(annotation).replace("typing.", "")
 

--- a/src/pydantic_espresso/errors.py
+++ b/src/pydantic_espresso/errors.py
@@ -1,0 +1,226 @@
+"""Turn a pydantic :class:`ValidationError` into a readable 'missing inputs' report.
+
+Follows pydantic's recommended pattern — catch the error and process
+``error.errors()`` — rather than intercepting validation. Construction still
+raises the usual :class:`pydantic.ValidationError`; call :func:`explain` on the
+caught error to get a grouped, recursive summary that names each missing field
+together with its type, units, and help text::
+
+    from pydantic import ValidationError
+    from pydantic_espresso.missing import explain
+
+    try:
+        inp = PWInput(**data)
+    except ValidationError as exc:
+        print(explain(exc, PWInput))
+"""
+
+from __future__ import annotations
+
+import textwrap
+from collections.abc import Sequence
+from typing import Any, Literal, get_args, get_origin
+
+from pydantic import BaseModel, ValidationError
+from pydantic.fields import FieldInfo
+
+from pydantic_espresso.quantity import quantity_for
+
+# Error categories rendered as the recursive missing-inputs summary; anything
+# else (a wrong type, a failed constraint) is listed verbatim from pydantic.
+_MISSING_ERROR_TYPES = {"missing", "union_tag_not_found"}
+_WIDTH = 96
+# Some QE help strings are pages long (e.g. ibrav documents every Bravais
+# lattice). Truncate to a sensible lead so the report stays scannable; the full
+# text remains on the field's ``description``.
+_DESC_MAX = 200
+
+
+def explain(error: ValidationError, model: type[BaseModel]) -> str:
+    """Render ``error`` (from validating ``model``) as a readable report.
+
+    ``model`` is the class whose construction failed; it is needed to resolve
+    each missing field's type/units/help (a ``ValidationError`` only carries
+    locations, not field metadata).
+    """
+    errors = error.errors()
+    missing = [e for e in errors if e["type"] in _MISSING_ERROR_TYPES]
+    other = [e for e in errors if e["type"] not in _MISSING_ERROR_TYPES]
+
+    lines: list[str] = []
+    if missing:
+        lines.append(f"{model.__name__} is missing required inputs:")
+        for top, group in _group_errors(model, missing).items():
+            lines.extend(_render_group(model, top, group))
+    if other:
+        if lines:
+            lines.append("")
+        lines.append("Other validation errors:")
+        for err in other:
+            loc = ".".join(str(s) for s in err["loc"])
+            lines.append(f"  {loc}: {err['msg']}")
+    return "\n".join(lines)
+
+
+def _union_members(annotation: Any) -> list[type[BaseModel]]:
+    """Return the BaseModel members of a (possibly ``X | Y``) field annotation."""
+    args = get_args(annotation)
+    candidates = args if args else (annotation,)
+    return [c for c in candidates if isinstance(c, type) and issubclass(c, BaseModel)]
+
+
+def _discriminator_name(field: FieldInfo | None) -> str | None:
+    """Return the field's discriminator name when it is a plain string key."""
+    if field is None:
+        return None
+    discriminator = field.discriminator
+    return discriminator if isinstance(discriminator, str) else None
+
+
+def _discriminator_options(field: FieldInfo) -> list[Any]:
+    """List the discriminator tag values across a discriminated-union field's variants."""
+    discriminator = _discriminator_name(field)
+    if discriminator is None:
+        return []
+    options: list[Any] = []
+    for member in _union_members(field.annotation):
+        info = member.model_fields.get(discriminator)
+        if info is not None and info.default is not None:
+            options.append(info.default)
+    return options
+
+
+def _annotation_str(annotation: Any) -> str:
+    """Render a field annotation compactly (basic type name, or a trimmed Literal)."""
+    if get_origin(annotation) is Literal:
+        values = get_args(annotation)
+        shown = ", ".join(repr(v) for v in values[:6])
+        if len(values) > 6:
+            shown += f", … ({len(values)} options)"
+        return f"Literal[{shown}]"
+    if isinstance(annotation, type):
+        return annotation.__name__
+    return str(annotation).replace("typing.", "")
+
+
+def _field_summary(name: str, info: FieldInfo | None, indent: int) -> list[str]:
+    """Render ``- name (type[, units]): help`` wrapped to the report width."""
+    bullet = " " * indent + "- "
+    if info is None:
+        return [bullet + name]
+    type_str = _annotation_str(info.annotation)
+    quantity = quantity_for(info)
+    units = f", {quantity.units}" if quantity and quantity.units else ""
+    head = f"{name} ({type_str}{units})"
+    description = " ".join((info.description or "").split())
+    if len(description) > _DESC_MAX:
+        description = description[:_DESC_MAX].rsplit(" ", 1)[0] + " …"
+    text = head if not description else f"{head}: {description}"
+    return textwrap.wrap(
+        text,
+        width=_WIDTH,
+        initial_indent=bullet,
+        subsequent_indent=" " * (indent + 2),
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [bullet + head]
+
+
+def _resolve_field_info(model_cls: type[BaseModel], loc: Sequence[Any]) -> FieldInfo | None:
+    """Walk a pydantic error ``loc`` to the target field's :class:`FieldInfo`.
+
+    Handles discriminated-union segments: when a field carries a discriminator
+    the following ``loc`` segment is the variant tag, which selects the member
+    model to descend into.
+    """
+    current: type[BaseModel] | None = model_cls
+    info: FieldInfo | None = None
+    i = 0
+    segments = list(loc)
+    while i < len(segments) and current is not None:
+        info = current.model_fields.get(str(segments[i]))
+        if info is None:
+            return None
+        i += 1
+        if i >= len(segments):
+            break
+        members = _union_members(info.annotation)
+        if not members:
+            return None
+        discriminator = _discriminator_name(info)
+        if discriminator is not None and len(members) > 1:
+            tag = str(segments[i])
+            i += 1
+            current = next(
+                (m for m in members if str(m.model_fields[discriminator].default) == tag),
+                members[0],
+            )
+        else:
+            current = members[0]
+    return info
+
+
+def _required_subfields(field: FieldInfo | None) -> list[tuple[str, FieldInfo]]:
+    """Return required (name, info) pairs of an absent block's (first variant) member."""
+    if field is None:
+        return []
+    members = _union_members(field.annotation)
+    if not members:
+        return []
+    return [(n, f) for n, f in members[0].model_fields.items() if f.is_required()]
+
+
+def _group_errors(model_cls: type[BaseModel], errors: Sequence[Any]) -> dict[str, dict[str, Any]]:
+    """Bucket missing/discriminator errors by top-level field into render-ready groups."""
+    groups: dict[str, dict[str, Any]] = {}
+    for err in errors:
+        loc = list(err["loc"])
+        top = str(loc[0])
+        field = model_cls.model_fields.get(top)
+        group = groups.setdefault(top, {"tag": None, "discriminator": None, "leaves": []})
+
+        discriminator = _discriminator_name(field)
+        if err["type"] == "union_tag_not_found":
+            # Prefer the field's own discriminator name; pydantic's ctx value is
+            # quote-wrapped (e.g. "'unit'").
+            group["discriminator"] = discriminator or (err.get("ctx") or {}).get("discriminator")
+            continue
+
+        rest = loc[1:]
+        if discriminator is not None and rest:
+            group["tag"] = f"{discriminator}={rest[0]!r}"
+            rest = rest[1:]
+        group["leaves"].append(loc if rest else None)  # None => the whole block is absent
+    return groups
+
+
+def _render_group(model_cls: type[BaseModel], top: str, group: dict[str, Any]) -> list[str]:
+    """Render one top-level field's missing-input lines."""
+    field = model_cls.model_fields.get(top)
+    head = f"  {top}" + (f" [{group['tag']}]" if group["tag"] else "")
+
+    if group["discriminator"] is not None:
+        options = _discriminator_options(field) if field is not None else []
+        note = f"missing discriminator {group['discriminator']!r}"
+        if options:
+            note += f" (one of {options})"
+        return [f"{head}: {note}"]
+
+    # A single ``None`` leaf means the whole block is absent.
+    if group["leaves"] == [None]:
+        discriminator = _discriminator_name(field)
+        options = _discriminator_options(field) if field is not None else []
+        suffix = f" — choose {discriminator!r}: {options}" if options and discriminator else ""
+        lines = [f"{head}: required{suffix}"]
+        lines.extend(
+            line
+            for name, info in _required_subfields(field)
+            for line in _field_summary(name, info, indent=6)
+        )
+        return lines
+
+    lines = [f"{head}:"]
+    for loc in group["leaves"]:
+        info = _resolve_field_info(model_cls, loc)
+        lines.extend(_field_summary(str(loc[-1]), info, indent=6))
+    return lines

--- a/src/pydantic_espresso/models/bgw2pw/develop.py
+++ b/src/pydantic_espresso/models/bgw2pw/develop.py
@@ -61,4 +61,4 @@ class InputBgw2pwNamelist(Namelist):
 class BGW2PWInput(EspressoInput):
     """Pydantic model for the input of `bgw2pw.x`."""
 
-    input_bgw2pw: InputBgw2pwNamelist | None = Field(None)
+    input_bgw2pw: InputBgw2pwNamelist = Field(...)

--- a/src/pydantic_espresso/models/cp/develop.py
+++ b/src/pydantic_espresso/models/cp/develop.py
@@ -1711,7 +1711,7 @@ class CPInput(EspressoInput):
     """Pydantic model for the input of `cp.x`."""
 
     control: ControlNamelist = Field(default_factory=lambda: ControlNamelist())
-    system: SystemNamelist | None = Field(None)
+    system: SystemNamelist = Field(...)
     electrons: ElectronsNamelist = Field(default_factory=lambda: ElectronsNamelist())
     ions: IonsNamelist = Field(default_factory=lambda: IonsNamelist())
     cell: CellNamelist = Field(default_factory=lambda: CellNamelist())

--- a/src/pydantic_espresso/models/ld1/develop.py
+++ b/src/pydantic_espresso/models/ld1/develop.py
@@ -562,5 +562,5 @@ class LD1Input(EspressoInput):
     """Pydantic model for the input of `ld1.x`."""
 
     input: InputNamelist = Field(default_factory=lambda: InputNamelist())
-    inputp: InputpNamelist | None = Field(None)
+    inputp: InputpNamelist = Field(...)
     test: TestNamelist = Field(default_factory=lambda: TestNamelist())

--- a/src/pydantic_espresso/models/oscdft_et/develop.py
+++ b/src/pydantic_espresso/models/oscdft_et/develop.py
@@ -40,4 +40,4 @@ class OscdftEtNamelistNamelist(Namelist):
 class OSCDFTETInput(EspressoInput):
     """Pydantic model for the input of `oscdft_et.x`."""
 
-    oscdft_et_namelist: OscdftEtNamelistNamelist | None = Field(None)
+    oscdft_et_namelist: OscdftEtNamelistNamelist = Field(...)

--- a/src/pydantic_espresso/models/oscdft_pp/develop.py
+++ b/src/pydantic_espresso/models/oscdft_pp/develop.py
@@ -23,4 +23,4 @@ class OscdftPpNamelistNamelist(Namelist):
 class OSCDFTPPInput(EspressoInput):
     """Pydantic model for the input of `oscdft_pp.x`."""
 
-    oscdft_pp_namelist: OscdftPpNamelistNamelist | None = Field(None)
+    oscdft_pp_namelist: OscdftPpNamelistNamelist = Field(...)

--- a/src/pydantic_espresso/models/ph/develop.py
+++ b/src/pydantic_espresso/models/ph/develop.py
@@ -620,4 +620,4 @@ class InputphNamelist(Namelist):
 class PHInput(EspressoInput):
     """Pydantic model for the input of `ph.x`."""
 
-    inputph: InputphNamelist | None = Field(None)
+    inputph: InputphNamelist = Field(...)

--- a/src/pydantic_espresso/models/postahc/develop.py
+++ b/src/pydantic_espresso/models/postahc/develop.py
@@ -127,4 +127,4 @@ class InputNamelist(Namelist):
 class POSTAHCInput(EspressoInput):
     """Pydantic model for the input of `postahc.x`."""
 
-    input: InputNamelist | None = Field(None)
+    input: InputNamelist = Field(...)

--- a/src/pydantic_espresso/models/pp/develop.py
+++ b/src/pydantic_espresso/models/pp/develop.py
@@ -545,4 +545,4 @@ class PPInput(EspressoInput):
     inputpp: InputppNamelist = Field(
         default_factory=lambda: InputppPlotNum0Or9Namelist(), discriminator="plot_num"
     )
-    plot: PlotNamelist | None = Field(None, discriminator="iflag")
+    plot: PlotNamelist = Field(..., discriminator="iflag")

--- a/src/pydantic_espresso/models/pprism/develop.py
+++ b/src/pydantic_espresso/models/pprism/develop.py
@@ -282,4 +282,4 @@ class PPRISMInput(EspressoInput):
     """Pydantic model for the input of `pprism.x`."""
 
     inputpp: InputppNamelist = Field(default_factory=lambda: InputppNamelist())
-    plot: PlotNamelist | None = Field(None, discriminator="iflag")
+    plot: PlotNamelist = Field(..., discriminator="iflag")

--- a/src/pydantic_espresso/models/pw/cards/k_points.py
+++ b/src/pydantic_espresso/models/pw/cards/k_points.py
@@ -25,14 +25,25 @@ class KPointsListCard(KPointsCardABC):
     class KPoint(BaseModel):
         """Pydantic model for a single k-point"""
 
-        coordinate: tuple[float, float, float] = Field(..., description="")
-        weight: float = Field(1, description="")
+        coordinate: tuple[float, float, float] = Field(
+            ...,
+            description="k-point coordinates (xk_x, xk_y, xk_z) in the units set by the card kind.",
+        )
+        weight: float = Field(1, description="k-point weight (wk).")
 
         def __str__(self) -> str:
             return f"{' '.join([str(x) for x in self.coordinate])} {self.weight}"
 
-    k_points: list[KPoint] = Field(default_factory=list)
-    kind: Literal["tpiba", "crystal", "tpiba_b", "crystal_b", "tpiba_c", "crystal_c"] = "tpiba"
+    k_points: list[KPoint] = Field(
+        default_factory=list, description="Explicit list of k-points and their weights."
+    )
+    kind: Literal["tpiba", "crystal", "tpiba_b", "crystal_b", "tpiba_c", "crystal_c"] = Field(
+        "tpiba",
+        description=(
+            "Units/mode for the explicit k-point list: 'tpiba' (2pi/a, default), 'crystal' "
+            "(crystal/reciprocal-lattice coordinates), or the '_b' band-path variants."
+        ),
+    )
 
     @field_validator("kind", mode="after")
     @classmethod
@@ -57,7 +68,9 @@ class KPointsListCard(KPointsCardABC):
 class KPointsGammaCard(KPointsCardABC):
     """Pydantic model for the K_POINTS card with kind == gamma."""
 
-    kind: Literal["gamma"] = Field("gamma", description="")
+    kind: Literal["gamma"] = Field(
+        "gamma", description="Use only the Gamma point, with Gamma-specific algorithms."
+    )
 
     def to_kpoints_list(self) -> KPointsListCard:
         """Convert to KPointsListCard."""
@@ -69,9 +82,23 @@ class KPointsGammaCard(KPointsCardABC):
 class KPointsGridCard(KPointsCardABC):
     """Pydantic model for the K_POINTS card with kind == automatic."""
 
-    grid: tuple[PositiveInt, PositiveInt, PositiveInt] = Field(..., description="")
-    offset: tuple[Literal[0, 1], Literal[0, 1], Literal[0, 1]] = Field((0, 0, 0), description="")
-    kind: Literal["automatic"] = Field("automatic", description="")
+    grid: tuple[PositiveInt, PositiveInt, PositiveInt] = Field(
+        ...,
+        description=(
+            "Monkhorst-Pack mesh dimensions (nk1, nk2, nk3): number of k-points along each "
+            "reciprocal-lattice direction of the uniform grid."
+        ),
+    )
+    offset: tuple[Literal[0, 1], Literal[0, 1], Literal[0, 1]] = Field(
+        (0, 0, 0),
+        description=(
+            "Grid offset (k1, k2, k3), each 0 or 1; a 1 shifts the grid by half a step along "
+            "that direction."
+        ),
+    )
+    kind: Literal["automatic"] = Field(
+        "automatic", description="Automatically generate a uniform Monkhorst-Pack k-point grid."
+    )
 
     def to_kpoints_list(self) -> KPointsListCard:
         """Convert to KPointsListCard."""

--- a/src/pydantic_espresso/models/pw/develop.py
+++ b/src/pydantic_espresso/models/pw/develop.py
@@ -2780,7 +2780,7 @@ class PWInput(EspressoInput):
     """Pydantic model for the input of `pw.x`."""
 
     control: ControlNamelist = Field(default_factory=lambda: ControlNamelist())
-    system: SystemNamelist | None = Field(None)
+    system: SystemNamelist = Field(...)
     electrons: ElectronsNamelist = Field(default_factory=lambda: ElectronsNamelist())
     ions: IonsNamelist = Field(default_factory=lambda: IonsNamelist())
     cell: CellNamelist = Field(default_factory=lambda: CellNamelist())

--- a/src/pydantic_espresso/models/pw2bgw/develop.py
+++ b/src/pydantic_espresso/models/pw2bgw/develop.py
@@ -301,4 +301,4 @@ class InputPw2bgwNamelist(Namelist):
 class PW2BGWInput(EspressoInput):
     """Pydantic model for the input of `pw2bgw.x`."""
 
-    input_pw2bgw: InputPw2bgwNamelist | None = Field(None)
+    input_pw2bgw: InputPw2bgwNamelist = Field(...)

--- a/src/pydantic_espresso/models/pw2gw/develop.py
+++ b/src/pydantic_espresso/models/pw2gw/develop.py
@@ -84,4 +84,4 @@ class InputppNamelist(Namelist):
 class PW2GWInput(EspressoInput):
     """Pydantic model for the input of `pw2gw.x`."""
 
-    inputpp: InputppNamelist | None = Field(None)
+    inputpp: InputppNamelist = Field(...)

--- a/src/pydantic_espresso/models/pw_with_os_cdft/develop.py
+++ b/src/pydantic_espresso/models/pw_with_os_cdft/develop.py
@@ -236,4 +236,4 @@ class OscdftNamelist(Namelist):
 class PWWITHOSCDFTInput(EspressoInput):
     """Pydantic model for the input of `pw.x with OS-CDFT`."""
 
-    oscdft: OscdftNamelist | None = Field(None)
+    oscdft: OscdftNamelist = Field(...)

--- a/src/pydantic_espresso/models/q2r/develop.py
+++ b/src/pydantic_espresso/models/q2r/develop.py
@@ -69,4 +69,4 @@ class InputNamelist(Namelist):
 class Q2RInput(EspressoInput):
     """Pydantic model for the input of `q2r.x`."""
 
-    input: InputNamelist | None = Field(None)
+    input: InputNamelist = Field(...)

--- a/src/pydantic_espresso/xml2pydantic.py
+++ b/src/pydantic_espresso/xml2pydantic.py
@@ -134,8 +134,10 @@ def convert_xml_tree_to_model(root: Element, version: str = "develop") -> str:
     imports: set[str] = set()
     needs_quantity = False
 
+    mandatory = _mandatory_namelists(root)
     for namelist in root.findall("namelist"):
-        field_line, namelist_block, uses_quantity = _process_namelist(namelist)
+        is_mandatory = namelist.attrib["name"] in mandatory
+        field_line, namelist_block, uses_quantity = _process_namelist(namelist, is_mandatory)
         needs_quantity = needs_quantity or uses_quantity
         fields.append(field_line)
         subclasses += namelist_block
@@ -158,12 +160,14 @@ def convert_xml_tree_to_model(root: Element, version: str = "develop") -> str:
     )
 
 
-def _process_namelist(namelist: Element) -> tuple[str, list[str], bool]:
+def _process_namelist(namelist: Element, is_mandatory: bool) -> tuple[str, list[str], bool]:
     """Process one ``<namelist>`` element.
 
     Returns ``(field_line, namelist_block, uses_quantity)`` where ``field_line``
     is the EspressoInput-level field referring to the namelist subclass and
-    ``namelist_block`` is the subclass definition lines.
+    ``namelist_block`` is the subclass definition lines. ``is_mandatory`` says
+    whether the namelist is required by the executable (unbracketed in the input
+    structure block); see ``_mandatory_namelists``.
     """
     _propagate_group_attributes(namelist)
 
@@ -174,7 +178,7 @@ def _process_namelist(namelist: Element) -> tuple[str, list[str], bool]:
     # subsequent ``<choose>``s) fall through to the single-class path.
     discriminated_choose = _find_discriminated_choose(namelist)
     if discriminated_choose is not None:
-        return _process_discriminated_namelist(namelist, discriminated_choose)
+        return _process_discriminated_namelist(namelist, discriminated_choose, is_mandatory)
 
     field_definitions, field_validators, uses_quantity = _collect_fields(
         namelist.findall(".//var"), namelist.findall(".//dimension")
@@ -182,24 +186,67 @@ def _process_namelist(namelist: Element) -> tuple[str, list[str], bool]:
 
     name = namelist.attrib["name"]
     type_name = f"{camel_case(name)}Namelist"
-    # If any ``<var>`` in this namelist is REQUIRED (and has no default) the
-    # namelist cannot be auto-constructed with zero args; expose it as
-    # ``Optional[...]`` defaulting to None so the user must supply it (or omit
-    # it entirely when not needed).
-    if _namelist_has_required_var(namelist):
-        field_line = _format_simple_field(
-            name.lower(),
-            f"{type_name} | None",
-            "Field(None)",
-        )
-    else:
-        field_line = _format_simple_field(
-            name.lower(),
-            type_name,
-            f"Field(default_factory=lambda: {type_name}())",
-        )
+    field_line = _namelist_field_line(
+        name, type_name, namelist, is_mandatory, factory_expr=f"{type_name}()"
+    )
     namelist_block = _generate_namelist(name, field_definitions, field_validators)
     return field_line, namelist_block, uses_quantity
+
+
+def _namelist_field_line(
+    name: str,
+    type_name: str,
+    namelist: Element,
+    is_mandatory: bool,
+    *,
+    factory_expr: str,
+    discriminator: str = "",
+) -> str:
+    """Render the EspressoInput-level field declaration for a namelist.
+
+    Three cases:
+
+    - no REQUIRED-without-default var -> ``Field(default_factory=...)`` (the
+      namelist can be auto-built from defaults).
+    - has a REQUIRED var and the namelist is *mandatory* -> ``Field(...)`` so
+      that omitting it raises (and pydantic then reports the missing fields).
+    - has a REQUIRED var but the namelist is *optional* -> ``Type | None =
+      Field(None)`` so it can be omitted when not needed.
+    """
+    discr_kwarg = f', discriminator="{discriminator}"' if discriminator else ""
+    if not _namelist_has_required_var(namelist):
+        return _format_simple_field(
+            name.lower(), type_name, f"Field(default_factory=lambda: {factory_expr}{discr_kwarg})"
+        )
+    if is_mandatory:
+        return _format_simple_field(name.lower(), type_name, f"Field(...{discr_kwarg})")
+    return _format_simple_field(name.lower(), f"{type_name} | None", f"Field(None{discr_kwarg})")
+
+
+def _mandatory_namelists(root: Element) -> set[str]:
+    """Return the names of namelists the executable requires (always present).
+
+    The ``<intro>`` text carries a "Structure of the input data" diagram in
+    which each namelist appears as ``&NAME``; optional namelists are wrapped in
+    square brackets, e.g. ``[ &CELL ... ]``. A namelist whose ``&NAME`` marker
+    is *not* bracketed is mandatory. A namelist not mentioned in the diagram is
+    treated as optional (conservative — we don't force-require it).
+    """
+    intro_el = root.find("intro")
+    if intro_el is None:
+        return set()
+    intro = "".join(intro_el.itertext())
+    # Search the structure diagram if present, else the whole intro.
+    anchor = re.search(r"Structure of the input data", intro, re.IGNORECASE)
+    structure = intro[anchor.end() :] if anchor else intro
+
+    mandatory: set[str] = set()
+    for namelist in root.findall("namelist"):
+        name = namelist.attrib["name"]
+        match = re.search(rf"(\[\s*)?&{re.escape(name)}\b", structure, re.IGNORECASE)
+        if match is not None and match.group(1) is None:
+            mandatory.add(name)
+    return mandatory
 
 
 def _namelist_has_required_var(namelist: Element) -> bool:
@@ -302,7 +349,7 @@ def _find_discriminated_choose(namelist: Element) -> Element | None:
 
 
 def _process_discriminated_namelist(
-    namelist: Element, choose: Element
+    namelist: Element, choose: Element, is_mandatory: bool
 ) -> tuple[str, list[str], bool]:
     """Emit a base class, one variant per branch, and a discriminated-union alias."""
     branches = [b for b in choose if b.tag in ("when", "elsewhen", "otherwise")]
@@ -366,21 +413,14 @@ def _process_discriminated_namelist(
     subclasses.extend(["", ""])
 
     default_variant = variant_names[0]
-    # If any variant has a REQUIRED-without-default ``<var>`` (unconditional or
-    # branch-local), the namelist can't be auto-constructed; expose it as
-    # ``Optional[...]`` defaulting to None.
-    if _namelist_has_required_var(namelist):
-        field_line = _format_simple_field(
-            name.lower(),
-            f"{alias_name} | None",
-            f'Field(None, discriminator="{discriminator}")',
-        )
-    else:
-        field_line = _format_simple_field(
-            name.lower(),
-            alias_name,
-            f'Field(default_factory=lambda: {default_variant}(), discriminator="{discriminator}")',
-        )
+    field_line = _namelist_field_line(
+        name,
+        alias_name,
+        namelist,
+        is_mandatory,
+        factory_expr=f"{default_variant}()",
+        discriminator=discriminator,
+    )
     return field_line, subclasses, uses_quantity
 
 

--- a/tests/models/test_other.py
+++ b/tests/models/test_other.py
@@ -3,6 +3,7 @@
 import pytest
 from packaging.version import Version
 
+from pydantic_espresso.base import EspressoInput
 from pydantic_espresso.models import get_module, versions
 
 
@@ -49,7 +50,14 @@ from pydantic_espresso.models import get_module, versions
 )
 @pytest.mark.parametrize("version", versions)
 def test_espresso_input(executable: str, version: Version) -> None:
-    """Test if the model can be instantiated."""
+    """The generated model is a valid, well-formed EspressoInput subclass.
+
+    We can no longer construct every model with no args — executables with a
+    mandatory namelist that has required fields (e.g. pw's SYSTEM) require those
+    inputs by design. Instead, smoke-test that the generated code produces a
+    structurally valid pydantic model by building its JSON schema, which
+    exercises every field and validator.
+    """
     # Import the model dynamically from pydantic_espresso.models.<executable>.<version>
     try:
         module = get_module(version, executable)
@@ -58,5 +66,7 @@ def test_espresso_input(executable: str, version: Version) -> None:
         return
     model = getattr(module, f"{executable.upper().replace('_', '')}Input")
 
-    # Instantiate the model
-    inp = model()  # noqa: F841
+    assert issubclass(model, EspressoInput)
+    # Building the JSON schema exercises every field/validator. (neb has no
+    # namelists or cards, so its property set is legitimately empty.)
+    assert "properties" in model.model_json_schema()

--- a/tests/models/test_pw.py
+++ b/tests/models/test_pw.py
@@ -36,6 +36,7 @@ def test_pw_espresso_input(version: Version, k_points: dict[str, Any]) -> None:
 
     # Instantiate the model
     inp = model(
+        system={"ibrav": 0, "nat": 1, "ntyp": 1, "ecutwfc": 30.0},
         cell_parameters={"unit": "alat", "vectors": np.identity(3)},
         atomic_positions={
             "unit": "alat",

--- a/tests/test_discriminated_namelists.py
+++ b/tests/test_discriminated_namelists.py
@@ -3,6 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
+from pydantic_espresso.errors import explain
 from pydantic_espresso.models.pp.develop import (
     PlotIflag0Or1Namelist,
     PlotIflag2Namelist,
@@ -67,3 +68,13 @@ def test_pp_plot_iflag2_omitting_required_raises() -> None:
     with pytest.raises(ValidationError) as exc:
         PPInput(plot={"iflag": 2})
     assert "nx" in str(exc.value)
+
+
+def test_explain_renders_missing_plot_fields() -> None:
+    """``explain`` summarises the missing iflag=2 branch fields with annotations."""
+    with pytest.raises(ValidationError) as exc:
+        PPInput(plot={"iflag": 2})
+    report = explain(exc.value, PPInput)
+    assert "PPInput is missing required inputs:" in report
+    for name in ("nx", "ny", "e1", "e2", "x0"):
+        assert name in report

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,82 @@
+"""Test the ``explain`` readable-error helper."""
+
+import pytest
+from pydantic import ValidationError
+
+from pydantic_espresso.errors import explain
+from pydantic_espresso.models.pw.develop import PWInput
+
+
+def test_explain_partial_input() -> None:
+    """A partial input is summarised per block with field annotations."""
+    with pytest.raises(ValidationError) as exc:
+        PWInput(  # type: ignore[call-arg]
+            system={"ibrav": 0, "ecutwfc": 30.0},  # missing nat, ntyp
+            cell_parameters={"vectors": [[1, 0, 0], [0, 1, 0], [0, 0, 1]]},  # no unit tag
+            k_points={"kind": "automatic"},  # missing grid
+            # atomic_positions omitted entirely
+        )
+    report = explain(exc.value, PWInput)
+
+    assert report.startswith("PWInput is missing required inputs:")
+    # Nested missing field, with its type rendered.
+    assert "- nat (int)" in report
+    # A required card absent entirely lists its discriminator choices.
+    assert "atomic_positions: required" in report
+    assert "'alat'" in report
+    # A card missing only its discriminator tag is reported as such.
+    assert "missing discriminator 'unit'" in report
+    # The selected variant of a partial discriminated card is shown.
+    assert "k_points [kind='automatic']" in report
+
+
+def test_explain_absent_namelist_expands_required_fields() -> None:
+    """Omitting a mandatory namelist lists each required field it needs."""
+    with pytest.raises(ValidationError) as exc:
+        PWInput(  # type: ignore[call-arg]
+            cell_parameters={"unit": "alat", "vectors": [[1, 0, 0], [0, 1, 0], [0, 0, 1]]},
+            atomic_positions={
+                "unit": "alat",
+                "positions": [{"species": "H", "position": [0.0, 0.0, 0.0]}],
+            },
+            k_points={"kind": "gamma"},
+        )
+    report = explain(exc.value, PWInput)
+    assert "system: required" in report
+    for field in ("ibrav", "nat", "ntyp", "ecutwfc"):
+        assert field in report
+    # Units are surfaced for quantity-bearing fields.
+    assert "ecutwfc (float, Ry)" in report
+
+
+def test_explain_units_in_report() -> None:
+    """A quantity-bearing missing field shows its units."""
+    with pytest.raises(ValidationError) as exc:
+        PWInput(
+            system={"ibrav": 0, "nat": 1, "ntyp": 1},  # missing ecutwfc (Ry)
+            cell_parameters={"unit": "alat", "vectors": [[1, 0, 0], [0, 1, 0], [0, 0, 1]]},
+            atomic_positions={
+                "unit": "alat",
+                "positions": [{"species": "H", "position": [0.0, 0.0, 0.0]}],
+            },
+            k_points={"kind": "gamma"},
+        )
+    report = explain(exc.value, PWInput)
+    assert "ecutwfc (float, Ry)" in report
+
+
+def test_explain_passes_through_type_errors() -> None:
+    """Non-missing errors (wrong types) are listed verbatim, not hidden."""
+    with pytest.raises(ValidationError) as exc:
+        PWInput(
+            system={"ibrav": 0, "nat": "notanint", "ntyp": 1, "ecutwfc": 30.0},
+            cell_parameters={"unit": "alat", "vectors": [[1, 0, 0], [0, 1, 0], [0, 0, 1]]},
+            atomic_positions={
+                "unit": "alat",
+                "positions": [{"species": "H", "position": [0.0, 0.0, 0.0]}],
+            },
+            k_points={"kind": "gamma"},
+        )
+    report = explain(exc.value, PWInput)
+    assert "Other validation errors:" in report
+    assert "system.nat" in report

--- a/tests/test_runtime_modules.py
+++ b/tests/test_runtime_modules.py
@@ -39,6 +39,7 @@ def test_namelist_str_renders_numeric() -> None:
 def test_espresso_input_str_includes_namelists_and_cards() -> None:
     """``EspressoInput.__str__`` renders set namelists and card text."""
     inp = PWInput(
+        system={"ibrav": 0, "nat": 1, "ntyp": 1, "ecutwfc": 30.0},
         cell_parameters={"unit": "alat", "vectors": np.identity(3)},
         atomic_positions={
             "unit": "alat",


### PR DESCRIPTION
## Friendlier input validation errors

Make it obvious what's wrong when an input is constructed incompletely.

### Highlights

- **`pydantic_espresso.errors.explain(error, model)`** — turns a caught `ValidationError` into a grouped, recursive report that lists each missing input per namelist/card, with its type, units, and help text. Construction still raises the standard `pydantic.ValidationError`; you call `explain` to get the readable summary.
- **Mandatory namelists are now required.** Namelists the executable always needs (e.g. pw's `SYSTEM`) are marked required, so omitting one is reported instead of silently passing — optional namelists (e.g. `FCP`, `RISM`) stay optional.
- **K_POINTS card fields now carry help text**, so they show up usefully in the report rather than as bare types.

### Example

```python
from pydantic import ValidationError
from pydantic_espresso.errors import explain
from pydantic_espresso.models.pw.develop import PWInput

try:
    inp = PWInput(system={"ibrav": 0, "ecutwfc": 30.0}, k_points={"kind": "automatic"})
except ValidationError as exc:
    print(explain(exc, PWInput))
```
returns
```
PWInput is missing required inputs:
  system:
      - nat (int): number of atoms in the unit cell (ALL atoms, except if space_group is set, in
        which case, INEQUIVALENT atoms)
      - ntyp (int): number of types of atoms in the unit cell
  atomic_positions: required — choose 'unit': ['alat', 'bohr', 'angstrom', 'crystal', 'crystal_sg']
  k_points [kind='automatic']:
      - grid (tuple[int, int, int]): Monkhorst-Pack mesh dimensions (nk1, nk2, nk3): number of
        k-points along each reciprocal-lattice direction of the uniform grid.
  cell_parameters: missing discriminator 'unit' (one of ['alat', 'bohr', 'angstrom'])
```
